### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ on sun position for a geo lat/long coordinates:
 
 Copy and edit the astral.yaml.example into the /opt/stackstorm/configs directory.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ### Triggers:
 
 ```text

--- a/actions/get_dawn.yaml
+++ b/actions/get_dawn.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_dawn"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Returns the time of dawn"
 enabled: true
 entry_point: "get_dawn.py"

--- a/actions/get_dusk.yaml
+++ b/actions/get_dusk.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_dusk"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Returns the time of dusk"
 enabled: true
 entry_point: "get_dusk.py"

--- a/actions/get_sunrise.yaml
+++ b/actions/get_sunrise.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_sunrise"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Returns the time of the sunrise"
 enabled: true
 entry_point: "get_sunrise.py"

--- a/actions/get_sunset.yaml
+++ b/actions/get_sunset.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_sunset"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Returns the time of the sunrise"
 enabled: true
 entry_point: "get_sunset.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : astral
 description : triggers for sunrise/sunset information
-version : 0.1.1
+version : 0.2.0
 author : Tim Braly
 email : tbraly@brocade.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.