### PR TITLE
Fix Python 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.2.2
+
+- Add explicit support for Python 2 and 3
+- Fix import for astral 2+ (available on Python 3.6+ only)
+
 # 0.2.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -12,7 +12,14 @@ limitations under the License.
 """
 
 from st2common.runners.base_action import Action
-from astral import Location
+
+try:
+    # The astral module was broken up into a package in astral 2.0, so use
+    # the updated import
+    from astral.location import Location
+except ImportError:
+    # Astral only installs <1.10 for Python < 3, so use the old import
+    from astral import Location
 
 
 class BaseAction(Action):

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ---
 name : astral
 description : triggers for sunrise/sunset information
-version: 0.2.1
+version: 0.2.2
 author : Tim Braly
 email : tbraly@brocade.com
 python_versions:

--- a/sensors/astral_sun_sensor.py
+++ b/sensors/astral_sun_sensor.py
@@ -1,6 +1,13 @@
 from st2reactor.sensor.base import PollingSensor
 import st2common.util.date as date
-from astral import Location
+
+try:
+    # The astral module was broken up into a package in astral 2.0, so use
+    # the updated import
+    from astral.location import Location
+except ImportError:
+    # Astral only installs <1.10 for Python < 3, so use the old import
+    from astral import Location
 
 
 __all__ = [


### PR DESCRIPTION
Update the changelog, bump pack version to 0.2.2, and fix an astral import to work with both Python 2 and 3.